### PR TITLE
Add packaging script for distribution

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Hugging Face access token for downloading models (optional)
+HF_TOKEN=
+# Secret key for securing Open WebUI sessions
+WEBUI_SECRET=
+# URL of the preview service (OpenAPI tool server)
+PREVIEW_SERVICE_URL=http://preview-service:5001
+
+# SQLite database location for persistent chat history
+DATABASE_URL=sqlite:///backend/data/sqlite.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,117 @@
 # OfflineLLM
+
+OfflineLLM bundles Open WebUI with the Qwen3-32B model, a PDF preview microservice, and optional Apache Tika for rich document parsing.  The stack runs fully offline using Docker Compose with NVIDIA GPU acceleration and supports loading additional local GGUF models through Ollama.
+
+## Repository layout
+
+```
+/docker            # Dockerfiles for images
+/services          # Application source code (preview service)
+/scripts           # Setup, packaging and launch scripts
+/models            # Placeholder for additional GGUF models
+/configs           # Desktop and service configuration files
+```
+
+## Build the base image
+
+```bash
+docker build -f docker/base.Dockerfile -t offline-llm/base:1.0 .
+```
+
+## Seed the Qwen3-32B model volume
+
+Place `Qwen3-32B-*.gguf` files in the repository root and run:
+
+```bash
+docker build -f docker/model.Dockerfile -t qwen3-model:1.0 .
+docker volume create qwen3-model
+docker run --rm -v qwen3-model:/models/qwen3-32b qwen3-model:1.0
+```
+
+## Launch
+
+Copy `.env.example` to `.env` and set `WEBUI_SECRET`. Adjust `PREVIEW_SERVICE_URL` if the preview service runs elsewhere; the default `DATABASE_URL` already points to the persistent SQLite database.
+
+Start the stack:
+
+```bash
+docker compose up --build -d
+```
+
+Open WebUI is available at [http://localhost:8080](http://localhost:8080).
+
+### Register the preview service
+
+1. Open WebUI and sign in.
+2. Navigate to **Settings → User → Tool Servers**.
+3. Click **Add** and set:
+   - **Name:** `PDF Preview Service`
+   - **OpenAPI URL:** `http://preview-service:5001/openapi.json`
+4. Save. The preview-service will now handle document uploads and knowledge ingestion.
+
+The preview-service image bundles Tika, OCR, and PDF libraries so it works fully offline with no runtime downloads.
+
+To launch from the desktop, copy the launcher and make it executable:
+
+```bash
+cp configs/OfflineLLM.desktop ~/.local/share/applications/
+chmod +x ~/.local/share/applications/OfflineLLM.desktop
+```
+
+Look for **Offline LLM Assistant** in your application menu.
+
+To keep the stack running in the background after login, install the systemd user service:
+
+```bash
+mkdir -p ~/.config/systemd/user
+cp configs/offline-llm.service ~/.config/systemd/user/
+systemctl --user daemon-reexec
+systemctl --user enable --now offline-llm.service
+```
+
+Ensure your `~/.bashrc` contains `unset DOCKER_HOST` so the service uses the default socket.
+
+## Multi‑model support
+
+Additional GGUF models can be added to the `models/` directory.  Inside the running Ollama container, use `ollama run /models/<model>.gguf` to load them alongside Qwen3-32B.
+
+## Persistent chat history
+
+Open WebUI stores conversation data in a SQLite database located at `./data/webui/sqlite.db` on the host, mounted as `/app/backend/data/sqlite.db` inside the container.  To back up your chat history, stop the stack and copy this file:
+
+```bash
+docker compose down
+cp data/webui/sqlite.db /path/to/backup/
+```
+
+Restoring is as simple as copying the file back to `data/webui/` before starting the containers again.
+
+## Git helper
+
+Add an alias that syncs a branch with `origin/main`:
+
+```bash
+git config --global alias.sync '!f() { git fetch origin && git switch "$1" && git rebase origin/main && git push origin "$1"; }; f'
+```
+
+Use it as `git sync feature-branch` or run the helper script:
+
+```bash
+scripts/git-sync.sh feature-branch
+```
+
+## Packaging
+
+Create a self-contained archive of the stack and required images:
+
+```bash
+scripts/package_offline_assistant.sh
+```
+
+## Update
+
+Refresh system packages, GPU drivers, Docker and images, then restart the stack:
+
+```bash
+scripts/update_offline_assistant.sh
+```

--- a/configs/OfflineLLM.desktop
+++ b/configs/OfflineLLM.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Offline LLM Assistant
+Comment=Chat with Qwen3-32B offline via Open WebUI
+Exec=/usr/bin/bash -c "$HOME/OfflineLLM/scripts/start_offline_assistant.sh"
+Icon=utilities-terminal
+Terminal=false
+Type=Application
+Categories=Utility;

--- a/configs/offline-llm.service
+++ b/configs/offline-llm.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Offline LLM Assistant
+After=network.target docker.service
+
+[Service]
+ExecStart=%h/OfflineLLM/scripts/start_offline_assistant.sh
+WorkingDirectory=%h/OfflineLLM
+Restart=always
+RestartSec=10
+Environment=DOCKER_HOST=unix:///var/run/docker.sock
+
+[Install]
+WantedBy=default.target

--- a/configs/openwebui/models/config.yaml
+++ b/configs/openwebui/models/config.yaml
@@ -1,0 +1,5 @@
+qwen3:
+  model_name: qwen3:32b
+  provider: ollama
+  api_base_url: http://ollama:11434
+  enabled: true

--- a/configs/openwebui/settings.yaml
+++ b/configs/openwebui/settings.yaml
@@ -1,0 +1,7 @@
+llm_backends:
+  - name: Ollama
+    url: http://ollama:11434
+documents:
+  preview:
+    name: PDF Preview Service
+    openapi_url: http://preview-service:5001/openapi.json

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,81 @@
+version: "3.9"
+services:
+  ollama:
+    image: ollama/ollama:0.9.5
+    command: ["ollama", "serve", "--model", "/models/qwen3-32b/Qwen3-32B-*.gguf"]
+    ports:
+      - "11434:11434"
+    volumes:
+      - qwen3-model:/models/qwen3-32b:ro
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/models"]
+      interval: 30s
+      retries: 5
+    deploy:
+      device_requests:
+        - driver: nvidia
+          count: all
+          capabilities: [gpu]
+    restart: unless-stopped
+
+  preview-service:
+    build:
+      context: .
+      dockerfile: docker/preview_service.Dockerfile
+    ports:
+      - "5001:5001"
+    volumes:
+      - ./data/preview:/data
+    depends_on:
+      tika:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5001/health"]
+      interval: 30s
+      retries: 3
+    restart: unless-stopped
+
+  tika:
+    image: apache/tika:3.2.1.0-full
+    restart: unless-stopped
+
+  open-webui:
+    build:
+      context: .
+      dockerfile: docker/webui.Dockerfile
+    image: offline-llm/webui:1.0
+    ports:
+      - "8080:8080"
+    environment:
+      - OW_CONFIG=/app/backend/data/settings.yaml
+      - WEBUI_SECRET=${WEBUI_SECRET:-changeme}
+      - PREVIEW_SERVICE_URL=${PREVIEW_SERVICE_URL:-http://preview-service:5001}
+      - DATABASE_URL=${DATABASE_URL:-sqlite:///backend/data/sqlite.db}
+      - OLLAMA_BASE_URL=http://ollama:11434
+      - SENTENCE_TRANSFORMERS_HOME=/app/embeddings
+      - EMBEDDING_MODEL=intfloat/multilingual-e5-base
+      - HF_HUB_OFFLINE=1
+      - TRANSFORMERS_OFFLINE=1
+      - SCARF_NO_ANALYTICS=true
+      - DO_NOT_TRACK=true
+      - ANONYMIZED_TELEMETRY=false
+    volumes:
+      - ./data/webui:/app/backend/data
+      - ./data/webui/embeddings:/app/embeddings
+      - ./configs/openwebui/settings.yaml:/app/backend/data/settings.yaml:ro
+      - ./configs/openwebui/models/config.yaml:/app/backend/data/models/config.yaml:ro
+    deploy:
+      device_requests:
+        - driver: nvidia
+          count: all
+          capabilities: [gpu]
+    depends_on:
+      ollama:
+        condition: service_healthy
+      preview-service:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  qwen3-model:
+    external: true

--- a/docker/base.Dockerfile
+++ b/docker/base.Dockerfile
@@ -1,0 +1,10 @@
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+
+LABEL org.opencontainers.image.source="https://github.com/yourrepo/offline-llm" \
+      org.opencontainers.image.description="Base image with Python3 and CUDA runtime"
+
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip git curl && \
+    rm -rf /var/lib/apt/lists/*
+
+

--- a/docker/model.Dockerfile
+++ b/docker/model.Dockerfile
@@ -1,0 +1,3 @@
+FROM debian:bookworm-slim
+COPY Qwen3-32B-*.gguf /models/qwen3-32b/
+

--- a/docker/preview_service.Dockerfile
+++ b/docker/preview_service.Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+WORKDIR /app
+RUN apt-get update && apt-get install -y \
+    poppler-utils \
+    tesseract-ocr \
+    tesseract-ocr-ces \
+    libmagic1 \
+    libgl1 \
+    unzip \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+COPY services/preview_service/requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+RUN mkdir -p /opt/tika && \
+    curl -L https://dlcdn.apache.org/tika/2.9.1/tika-server-standard-2.9.1.jar -o /opt/tika/tika.jar
+COPY services/preview_service/ .
+ENV TIKA_SERVER_JAR=/opt/tika/tika.jar
+EXPOSE 5001
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD curl -f http://localhost:5001/health || exit 1
+CMD ["python", "app.py"]

--- a/docker/webui-entrypoint.sh
+++ b/docker/webui-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+OLLAMA_URL="${OLLAMA_URL:-http://ollama:11434}"
+PREVIEW_URL="${PREVIEW_SERVICE_URL:-http://preview-service:5001}"
+
+echo "Waiting for Ollama at $OLLAMA_URL..."
+until curl -sSf "$OLLAMA_URL/models" >/dev/null; do
+  sleep 2
+done
+echo "Connected to Ollama at $OLLAMA_URL"
+
+echo "Waiting for Preview Service at $PREVIEW_URL..."
+until curl -sSf "$PREVIEW_URL/health" >/dev/null; do
+  sleep 2
+done
+echo "Connected to Preview Service at $PREVIEW_URL"
+
+DB_PATH="/app/backend/data/sqlite.db"
+if [ ! -f "$DB_PATH" ]; then
+  echo "Initializing chat database at $DB_PATH"
+  touch "$DB_PATH"
+else
+  echo "Using existing chat database at $DB_PATH"
+fi
+
+echo "Starting Open WebUI"
+exec "$@"

--- a/docker/webui.Dockerfile
+++ b/docker/webui.Dockerfile
@@ -1,0 +1,20 @@
+FROM ghcr.io/open-webui/open-webui:ollama
+
+ENV SCARF_NO_ANALYTICS=true \
+    DO_NOT_TRACK=true \
+    ANONYMIZED_TELEMETRY=false \
+    HF_HUB_OFFLINE=1 \
+    TRANSFORMERS_OFFLINE=1 \
+    SENTENCE_TRANSFORMERS_HOME=/app/embeddings \
+    EMBEDDING_MODEL=intfloat/multilingual-e5-base
+
+# Install sentence-transformers and preload embedding model
+RUN pip install --no-cache-dir sentence-transformers \
+    && mkdir -p /app/embeddings \
+    && python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('intfloat/multilingual-e5-base', cache_folder='/app/embeddings')"
+
+COPY docker/webui-entrypoint.sh /usr/local/bin/webui-entrypoint.sh
+RUN chmod +x /usr/local/bin/webui-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/webui-entrypoint.sh"]
+CMD ["bash","start.sh"]

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,239 @@
+# Offline Qwen3-32B Inference Stack
+
+This guide walks through setting up a fully containerized offline LLM stack for Czech business report analysis. It includes a Flask-based PDF preview service, an Ollama backend running Qwen3-32B, Open WebUI, and an optional Apache Tika server.
+
+## Prerequisites
+- **OS**: Ubuntu 22.04 LTS
+- **GPU**: NVIDIA GPU with driver 535+ and CUDA 12.2
+- **Hardware**: 50 GB free disk, 16 GB RAM
+- **Tools**: Docker Engine & Compose, NVIDIA Container Toolkit, Git, curl
+
+All commands assume a non-root user with `sudo` privileges.
+
+## 1. Install System Packages
+Update the system and install utilities:
+```bash
+sudo apt update && sudo apt upgrade -y
+sudo apt install -y git curl
+```
+
+Add Docker's repository using a keyring and install Docker Engine and the Compose plugin:
+```bash
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | \
+  sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] \ 
+  https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt update
+sudo apt install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+sudo usermod -aG docker $USER
+newgrp docker
+```
+Verify Docker installation:
+```bash
+docker version
+docker compose version
+```
+
+## 2. NVIDIA Drivers and Container Toolkit
+Install the proprietary driver and toolkit:
+```bash
+sudo apt install -y nvidia-driver-535 nvidia-utils-535
+sudo reboot
+nvidia-smi
+```
+Install the container toolkit using a signed repo:
+```bash
+distribution=$( . /etc/os-release; echo $ID$VERSION_ID )
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
+  gpg --dearmor | sudo tee /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg > /dev/null
+
+echo "deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] \ 
+  https://nvidia.github.io/libnvidia-container/$distribution/ /" | \
+  sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list > /dev/null
+
+sudo apt update
+sudo apt install -y nvidia-container-toolkit
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+```
+Test with:
+```bash
+docker run --rm --gpus all nvidia/cuda:12.2.0-runtime-ubuntu22.04 nvidia-smi
+```
+
+## 3. Project Structure
+Create a directory and initialise Git:
+```bash
+mkdir offline-llm && cd offline-llm
+git init
+```
+Suggested layout:
+```
+offline-llm/
+├── services/
+│   └── preview_service/
+├── models/
+├── docker/
+└── docs/
+```
+
+## 4. Base Docker Image
+Create `docker/base.Dockerfile`:
+```Dockerfile
+FROM nvidia/cuda:12.2.0-runtime-ubuntu22.04
+LABEL org.opencontainers.image.source="https://github.com/yourrepo/offline-llm" \
+      org.opencontainers.image.description="Base image with Python3 and CUDA runtime"
+RUN apt-get update && apt-get install -y python3 python3-pip git curl && rm -rf /var/lib/apt/lists/*
+```
+Build it:
+```bash
+docker build -f docker/base.Dockerfile -t offline-llm/base:1.0 .
+```
+Use it in another Dockerfile:
+```Dockerfile
+FROM offline-llm/base:1.0
+```
+Build a minimal image with the Qwen3-32B model and fill a volume:
+
+```bash
+docker build -f docker/model.Dockerfile -t qwen3-model:1.0 .
+docker volume create qwen3-model
+docker run --rm -v qwen3-model:/models/qwen3-32b qwen3-model:1.0
+```
+
+
+## 5. Docker Compose Stack
+Create `docker-compose.yaml`:
+```yaml
+version: "3.9"
+services:
+  preview-service:
+    build:
+      context: .
+      dockerfile: docker/preview_service.Dockerfile
+    image: offline-llm/preview:1.0
+    volumes:
+      - preview_data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5001/health"]
+      interval: 30s
+      retries: 3
+    restart: unless-stopped
+
+  ollama:
+    image: ollama/ollama:0.9.5
+    command: ["ollama", "serve", "--model", "/models/qwen3-32b/Qwen3-32B-*.gguf"]
+    ports:
+      - "11434:11434"
+    volumes:
+      - qwen3-model:/models/qwen3-32b:ro
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11434/models"]
+      interval: 30s
+      retries: 5
+    deploy:
+      device_requests:
+        - driver: nvidia
+          count: all
+          capabilities: [gpu]
+    restart: unless-stopped
+
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:ollama
+    ports:
+      - "8080:8080"
+    volumes:
+      - webui_data:/app/backend/data
+    depends_on:
+      ollama:
+        condition: service_started
+      preview-service:
+        condition: service_started
+    restart: unless-stopped
+
+  tika:
+    image: apache/tika:3.2.1.0-full
+    restart: unless-stopped
+
+volumes:
+  qwen3-model:
+  webui_data:
+  preview_data:
+```
+
+
+## 6. Preview Service Container
+`services/preview_service/requirements.txt`:
+```
+fastapi==0.100.0
+uvicorn[standard]==0.23.0
+PyMuPDF==1.26.3
+pdf2image==1.16.3
+pytesseract==0.3.10
+Pillow==9.5.0
+```
+
+`docker/preview_service.Dockerfile`:
+```Dockerfile
+FROM offline-llm/base:1.0
+WORKDIR /app
+RUN apt-get update && apt-get install -y \
+    poppler-utils tesseract-ocr tesseract-ocr-ces \
+    && rm -rf /var/lib/apt/lists/*
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+EXPOSE 5001
+CMD ["python", "app.py"]
+```
+
+`services/preview_service/app.py` example:
+```python
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+@app.post("/extract")
+def extract():
+    # handle uploaded file and return extracted text
+    return jsonify({"text": "...", "language": "en"})
+```
+
+## 7. Launch the Stack
+Build and start the containers:
+```bash
+docker compose up --build -d
+```
+Check status:
+```bash
+docker compose ps
+```
+Open WebUI at <http://localhost:8080>.
+
+## 8. Maintenance Tips
+- Keep images and host packages updated.
+- Limit container privileges by running as non-root where possible.
+- Use healthchecks and `restart: unless-stopped` to improve reliability.
+- Consider a CI pipeline to rebuild images and scan for vulnerabilities.
+
+## 9. Desktop launcher and systemd service
+Copy the provided launcher and service files to integrate with your desktop environment:
+
+```bash
+cp configs/OfflineLLM.desktop ~/.local/share/applications/
+chmod +x ~/.local/share/applications/OfflineLLM.desktop
+
+mkdir -p ~/.config/systemd/user
+cp configs/offline-llm.service ~/.config/systemd/user/
+systemctl --user daemon-reexec
+systemctl --user enable --now offline-llm.service
+```
+
+The desktop launcher appears as **Offline LLM Assistant**. The systemd service starts the stack on login and restarts it if it exits. Ensure `unset DOCKER_HOST` is present in your `~/.bashrc` so Docker uses the default socket.

--- a/models/.gitignore
+++ b/models/.gitignore
@@ -1,0 +1,2 @@
+*
+!/.gitignore

--- a/scripts/git-sync.sh
+++ b/scripts/git-sync.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <branch-name>"
+    exit 1
+fi
+branch="$1"
+
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    echo "Error: not a git repository" >&2
+    exit 1
+fi
+
+if ! git fetch origin; then
+    echo "Failed to fetch from origin" >&2
+    exit 1
+fi
+
+if ! git switch "$branch"; then
+    echo "Failed to switch to branch '$branch'" >&2
+    exit 1
+fi
+
+if ! git rebase origin/main; then
+    echo "Rebase onto origin/main failed" >&2
+    exit 1
+fi
+
+if ! git push origin "$branch"; then
+    echo "Push to origin failed" >&2
+    exit 1
+fi
+
+echo "Branch '$branch' synchronized with origin/main" 

--- a/scripts/package_offline_assistant.sh
+++ b/scripts/package_offline_assistant.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Package the offline AI assistant stack into offline-assistant.tar.gz
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STAGING_DIR="$(mktemp -d)"
+IMAGES_DIR="$STAGING_DIR/images"
+trap 'rm -rf "$STAGING_DIR"' EXIT
+
+mkdir -p "$IMAGES_DIR"
+
+# Copy core scripts and config
+cp "$REPO_ROOT/scripts/setup.sh" "$STAGING_DIR/"
+cp "$REPO_ROOT/scripts/start_offline_assistant.sh" "$STAGING_DIR/"
+cp "$REPO_ROOT/configs/OfflineLLM.desktop" "$STAGING_DIR/"
+cp "$REPO_ROOT/.env.example" "$STAGING_DIR/"
+mkdir -p "$STAGING_DIR/configs/openwebui"
+cp "$REPO_ROOT/configs/openwebui/settings.yaml" "$STAGING_DIR/configs/openwebui/"
+cp -r "$REPO_ROOT/configs/openwebui/models" "$STAGING_DIR/configs/openwebui/"
+
+# Copy services and dockerfiles
+mkdir -p "$STAGING_DIR/services"
+cp -r "$REPO_ROOT/services/preview_service" "$STAGING_DIR/services/"
+cp -r "$REPO_ROOT/docker" "$STAGING_DIR/"
+
+# Compose file
+cp "$REPO_ROOT/docker-compose.yaml" "$STAGING_DIR/"
+
+
+# Save Docker images
+
+echo "Saving Docker images..."
+
+docker save offline-llm/preview:1.0 -o "$IMAGES_DIR/preview-service.tar"
+
+docker save offline-llm/webui:1.0 -o "$IMAGES_DIR/open-webui.tar"
+
+docker save ollama/ollama:0.9.5 -o "$IMAGES_DIR/ollama.tar"
+
+# Create archive
+
+tar -C "$STAGING_DIR" -czf offline-assistant.tar.gz .
+
+echo "Created archive offline-assistant.tar.gz"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install Docker Engine and Docker Compose plugin
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg lsb-release
+sudo mkdir -p /etc/apt/keyrings
+if ! curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg; then
+    echo "[ERROR] Failed to download Docker GPG key" >&2
+    exit 1
+fi
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+sudo systemctl enable --now docker
+sudo usermod -aG docker "$USER" || true
+
+# Install NVIDIA Container Toolkit
+if ! command -v nvidia-smi > /dev/null; then
+    echo "NVIDIA drivers are required but not detected. Please install them first." >&2
+else
+    distribution=$( . /etc/os-release; echo $ID$VERSION_ID )
+    if ! curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /etc/apt/keyrings/nvidia-container-toolkit.gpg; then
+        echo "[ERROR] Failed to download NVIDIA GPG key" >&2
+        exit 1
+    fi
+    if ! curl -fsSL https://nvidia.github.io/libnvidia-container/$distribution/libnvidia-container.list | \
+        sed 's#deb https://#deb [signed-by=/etc/apt/keyrings/nvidia-container-toolkit.gpg] https://#' | \
+        sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list; then
+        echo "[ERROR] Failed to fetch NVIDIA container repository list" >&2
+        exit 1
+    fi
+    sudo apt-get update
+    sudo apt-get install -y nvidia-container-toolkit
+    sudo nvidia-ctk runtime configure --runtime=docker
+    sudo systemctl restart docker
+fi
+
+# Log into Hugging Face CLI
+if ! command -v huggingface-cli > /dev/null; then
+    pip install --user --upgrade huggingface-hub
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
+if [ -z "${HF_TOKEN:-}" ]; then
+    read -rp "Enter your Hugging Face token: " HF_TOKEN
+fi
+huggingface-cli login --token "$HF_TOKEN" --stdin <<< "$HF_TOKEN"
+
+# Download the Qwen3-32B model
+mkdir -p models
+huggingface-cli download Qwen/Qwen3-32B --local-dir models/Qwen3-32B --local-dir-use-symlinks False
+
+# Pull required Docker images
+docker pull ollama/ollama:0.9.5
+
+echo "Setup complete. Start the stack with:\n  docker compose up -d"

--- a/scripts/start_offline_assistant.sh
+++ b/scripts/start_offline_assistant.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Change to the directory where this script resides
+cd "$(dirname "$(realpath "$0")")/.."
+
+# Start the Docker Compose stack
+docker compose up -d
+
+# Wait for Open WebUI to become available
+printf "Waiting for Open WebUI..."
+until curl -fs http://localhost:8080 >/dev/null 2>&1; do
+  printf "."
+  sleep 2
+done
+printf " done\n"
+
+# Launch the browser
+xdg-open http://localhost:8080 >/dev/null 2>&1 &
+
+echo "[INFO] OfflineLLM startup script completed successfully."

--- a/scripts/update_offline_assistant.sh
+++ b/scripts/update_offline_assistant.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_step() {
+  echo -e "\n=== $1 ===\n"
+  date
+}
+
+log_step "System Packages"
+sudo apt update && sudo apt upgrade -y --with-new-pkgs
+
+log_step "GPU Drivers (NVIDIA)"
+if command -v nvidia-smi >/dev/null 2>&1; then
+  echo "Current NVIDIA driver version: $(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n1)"
+else
+  echo "nvidia-smi not found; proceeding with driver installation"
+fi
+if [ ! -f /etc/apt/sources.list.d/nvidia-container-toolkit.list ]; then
+  distribution=$(. /etc/os-release; echo $ID$VERSION_ID)
+  curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+  curl -s -L https://nvidia.github.io/libnvidia-container/stable/$distribution/libnvidia-container.list | \
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list > /dev/null
+fi
+sudo apt update
+sudo apt install -y nvidia-driver-535 nvidia-container-toolkit
+sudo systemctl restart docker
+
+log_step "Docker Engine & Compose"
+curl -fsSL https://get.docker.com -o /tmp/get-docker.sh
+sudo sh /tmp/get-docker.sh
+rm /tmp/get-docker.sh
+
+mkdir -p ~/.docker/cli-plugins
+curl -SL https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose
+chmod +x ~/.docker/cli-plugins/docker-compose
+
+docker --version
+docker compose version
+
+log_step "Docker Images"
+docker compose pull
+docker compose build
+
+log_step "Python Requirements"
+if [ -f services/preview_service/requirements.txt ]; then
+  if grep -q 'pip install --no-cache-dir -r requirements.txt' docker/preview_service.Dockerfile; then
+    echo "Verified pip install in docker/preview_service.Dockerfile"
+  else
+    echo "Warning: docker/preview_service.Dockerfile missing pip install line"
+  fi
+fi
+
+log_step "Desktop Launcher"
+desktop_file="$HOME/.local/share/applications/offline-llm.desktop"
+if [ ! -f "$desktop_file" ]; then
+  mkdir -p "$(dirname "$desktop_file")"
+  cat <<'LAUNCHER' > "$desktop_file"
+[Desktop Entry]
+Name=Offline LLM Assistant
+Exec=$HOME/OfflineLLM/scripts/start_offline_assistant.sh
+Icon=utilities-terminal
+Terminal=false
+Type=Application
+Categories=Utility;
+LAUNCHER
+  chmod +x "$desktop_file"
+fi
+
+log_step "Restarting Offline LLM"
+docker compose down
+./start_offline_assistant.sh

--- a/services/preview_service/app.py
+++ b/services/preview_service/app.py
@@ -1,0 +1,152 @@
+import os
+import signal
+from flask import Flask, request, jsonify
+from werkzeug.utils import secure_filename
+from werkzeug.exceptions import RequestEntityTooLarge
+import fitz  # PyMuPDF
+from pdf2image import convert_from_path
+import pytesseract
+from PIL import Image
+import docx
+import chardet
+import magic
+from tika import parser
+from langdetect import detect, LangDetectException
+
+UPLOAD_DIR = "/data"
+MAX_CONTENT_LENGTH = 50 * 1024 * 1024  # 50MB
+PROCESS_TIMEOUT = 30  # seconds
+
+os.environ.setdefault("TIKA_SERVER_JAR", "/opt/tika/tika.jar")
+
+app = Flask(__name__)
+app.config["UPLOAD_FOLDER"] = UPLOAD_DIR
+app.config["MAX_CONTENT_LENGTH"] = MAX_CONTENT_LENGTH
+
+
+class TimeoutError(Exception):
+    pass
+
+
+def _timeout_handler(signum, frame):
+    raise TimeoutError("processing timed out")
+
+
+def run_with_timeout(func, *args, **kwargs):
+    signal.signal(signal.SIGALRM, _timeout_handler)
+    signal.alarm(PROCESS_TIMEOUT)
+    try:
+        return func(*args, **kwargs)
+    finally:
+        signal.alarm(0)
+
+
+@app.errorhandler(RequestEntityTooLarge)
+def handle_file_too_large(e):
+    return jsonify({"error": "file too large"}), 413
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+def detect_language(text: str) -> str:
+    try:
+        return detect(text) if text.strip() else "unknown"
+    except LangDetectException:
+        return "unknown"
+
+
+def extract_pdf(path: str) -> str:
+    doc = fitz.open(path)
+    text = "".join(page.get_text() for page in doc)
+    if text.strip():
+        return text
+    images = convert_from_path(path)
+    ocr_text = []
+    for img in images:
+        ocr_text.append(pytesseract.image_to_string(img, lang="ces+eng"))
+    return "\n".join(ocr_text)
+
+
+def extract_docx(path: str) -> str:
+    document = docx.Document(path)
+    return "\n".join([p.text for p in document.paragraphs])
+
+
+def extract_txt(path: str) -> str:
+    with open(path, "rb") as f:
+        raw = f.read()
+    enc = chardet.detect(raw).get("encoding")
+    if enc:
+        try:
+            return raw.decode(enc)
+        except Exception:
+            pass
+    # fallback to tika
+    parsed = parser.from_file(path)
+    return parsed.get("content", "")
+
+
+def extract_image(path: str) -> str:
+    image = Image.open(path)
+    return pytesseract.image_to_string(image, lang="ces+eng")
+
+
+def process_file(path: str):
+    mime = magic.from_file(path, mime=True)
+    if mime == "application/pdf":
+        file_type = "pdf"
+        text = extract_pdf(path)
+    elif mime in (
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ):
+        file_type = "docx"
+        text = extract_docx(path)
+    elif mime.startswith("text"):
+        file_type = "txt"
+        text = extract_txt(path)
+    elif mime.startswith("image"):
+        file_type = "image"
+        text = extract_image(path)
+    else:
+        file_type = "unknown"
+        text = ""
+    return file_type, text
+
+
+@app.post("/extract")
+def extract():
+    if "file" not in request.files:
+        return jsonify({"error": "no file provided"}), 400
+    file = request.files["file"]
+    if file.filename == "":
+        return jsonify({"error": "empty filename"}), 400
+
+    filename = secure_filename(file.filename)
+    os.makedirs(app.config["UPLOAD_FOLDER"], exist_ok=True)
+    temp_path = os.path.join(app.config["UPLOAD_FOLDER"], filename)
+    file.save(temp_path)
+    try:
+        file_type, text = run_with_timeout(process_file, temp_path)
+        language = detect_language(text)
+        return jsonify({
+            "text": text,
+            "language": language,
+            "type": file_type,
+            "filename": filename,
+        })
+    except TimeoutError:
+        return jsonify({"error": "processing timeout"}), 408
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+    finally:
+        try:
+            os.remove(temp_path)
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5001)

--- a/services/preview_service/requirements.txt
+++ b/services/preview_service/requirements.txt
@@ -1,0 +1,9 @@
+flask
+pytesseract
+pdf2image
+python-docx
+chardet
+PyMuPDF
+python-magic
+tika
+langdetect


### PR DESCRIPTION
## Summary
- consolidate configuration and documentation on the Qwen3-32B model across scripts, configs, and docs
- rework docker compose to mount a pre-seeded `qwen3-model` volume and reference it in the Ollama service
- improve packaging and update scripts with correct paths and desktop integration
- drop bundled PNG icon assets and rely on default system icons

## Testing
- `/bin/bash -n scripts/setup.sh`
- `/bin/bash -n scripts/start_offline_assistant.sh`
- `/bin/bash -n scripts/package_offline_assistant.sh`
- `/bin/bash -n scripts/update_offline_assistant.sh`
- `/bin/bash -n scripts/git-sync.sh`
- `/usr/bin/python3 -m py_compile services/preview_service/app.py`
- `/usr/bin/docker compose -f docker-compose.yaml config` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68877ec8d6f4832c8d3fcdb16144e21d